### PR TITLE
Fix text wrapping in the buttons

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -16,7 +16,7 @@ var SoundBoard = {
         for (var i = 0; i < numTracks; i++) {
             var tdEl = $(cellTemplate(tracks[i]));
 
-            if (i % 6 === 0) {
+            if (i % 5 === 0) {
                 var row = $(document.createElement("tr"));
                 table.append(row);
             }


### PR DESCRIPTION
Six buttons to a row causes the text to wrap inside the buttons on my browser.  (I can upload a screenshot if you'd like).  The easiest fix is to just reduce the number of buttons to 5 a row so they each have more space.  Otherwise, reduce the font size / reduce the amount of text in each button could also work, but dealing with fonts is a pain since it renders differently on each system.

I would recommend allowing X buttons per row and each button would take up as much space as it needs for its text. A downside is there wouldn't be any columns.
